### PR TITLE
Update the commit hash in the podspec to work and pass validation.

### DIFF
--- a/Forecastr.podspec
+++ b/Forecastr.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/iwasrobbed/Forecastr"
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.author       = 'Rob Phillips'
-  s.source       = { :git => "https://github.com/iwasrobbed/Forecastr.git", :commit => "c14e0bc9de" }
+  s.source       = { :git => "https://github.com/iwasrobbed/Forecastr.git", :commit => "4638d7b2f6" }
   s.platform     = :ios, '5.0'
   s.source_files = 'Forecastr'
   s.resources = "Forecastr/*.plist"


### PR DESCRIPTION
Whoops. Had the wrong commit hash in there. This should fix most of it... also, here's the standard cocoapods spiel about tagging things. For now I'm using commit hashes, but in the future, when there's more stable releases (if ever) you should tag them and we can create a podspec of the tag instead of the commit.

---

I’ve recently added [Forecastr](https://github.com/CocoaPods/Specs/tree/master/Forecastr) to the [CocoaPods](https://github.com/CocoaPods/CocoaPods) package manager repo.

CocoaPods is a tool for managing dependencies for OSX and iOS Xcode projects and provides a central repository for iOS/OSX libraries. This makes adding libraries to a project and updating them extremely easy and it will help users to resolve dependencies of the libraries they use.

However, Forecastr doesn't have any version tags. I’ve added the current HEAD as version 0.0.1, but a version tag will make dependency resolution much easier.

[Semantic version](http://semver.org) tags (instead of plain commit hashes/revisions) allow for [resolution of cross-dependencies](https://github.com/CocoaPods/Specs/wiki/Cross-dependencies-resolution-example).

In case you didn’t know this yet; you can tag the current HEAD as, for instance, version 1.0.0, like so:

```
$ git tag -a 1.0.0 -m "Tag release 1.0.0"
$ git push --tags
```
