### PR TITLE
added the extend option, ref. "22 May 2013" changes to Forecast.io

### DIFF
--- a/Forecastr/Forecastr+CLLocation.h
+++ b/Forecastr/Forecastr+CLLocation.h
@@ -45,8 +45,16 @@
 - (void)getForecastForLocation:(CLLocation *)location
                           time:(NSNumber *)time
                     exclusions:(NSArray *)exclusions
+                        extend:(NSString*)extendCommand
                        success:(void (^)(id JSON))success
                        failure:(void (^)(NSError *error, id response))failure;
+
+- (void)getForecastForLocation:(CLLocation *)location
+                          time:(NSNumber *)time
+                    exclusions:(NSArray *)exclusions
+                       success:(void (^)(id JSON))success
+                       failure:(void (^)(NSError *error, id response))failure DEPRECATED_ATTRIBUTE;
+
 
 /**
  * Removes a cached forecast in case you want to refresh it prematurely
@@ -56,6 +64,8 @@
  * @param time (Optional) The desired time of the forecast in UNIX GMT format
  * @param exclusions (Optional) An array which specifies which data blocks you would like left off the response
  */
-- (void)removeCachedForecastForLocation:(CLLocation *)location time:(NSNumber *)time exclusions:(NSArray *)exclusions;
+- (void)removeCachedForecastForLocation:(CLLocation *)location time:(NSNumber *)time exclusions:(NSArray *)exclusions extend:(NSString*)extendCommand;
+
+- (void)removeCachedForecastForLocation:(CLLocation *)location time:(NSNumber *)time exclusions:(NSArray *)exclusions DEPRECATED_ATTRIBUTE;
 
 @end

--- a/Forecastr/Forecastr+CLLocation.m
+++ b/Forecastr/Forecastr+CLLocation.m
@@ -31,28 +31,46 @@
 - (void)getForecastForLocation:(CLLocation *)location
                           time:(NSNumber *)time
                     exclusions:(NSArray *)exclusions
+                        extend:(NSString*)extendCommand
                        success:(void (^)(id JSON))success
                        failure:(void (^)(NSError *error, id response))failure
 {
     float latitude = location.coordinate.latitude;
     float longitude = location.coordinate.longitude;
     
-    [self getForecastForLatitude:latitude longitude:longitude time:time exclusions:exclusions success:^(id JSON) {
+  [self getForecastForLatitude:latitude longitude:longitude time:time exclusions:exclusions extend:extendCommand success:^(id JSON) {
         success(JSON);
     } failure:^(NSError *error, id response) {
         failure(error, response);
     }];
 }
 
+- (void)getForecastForLocation:(CLLocation *)location
+                          time:(NSNumber *)time
+                    exclusions:(NSArray *)exclusions
+                       success:(void (^)(id JSON))success
+                       failure:(void (^)(NSError *error, id response))failure
+{
+  [self getForecastForLocation:location time:time exclusions:exclusions extend:nil success:success failure:failure];
+}
+
 // Removes a cached forecast in case you want to refresh it prematurely
 - (void)removeCachedForecastForLocation:(CLLocation *)location
                                    time:(NSNumber *)time
                              exclusions:(NSArray *)exclusions
+                                 extend:(NSString*)extendCommand
 {
     float latitude = location.coordinate.latitude;
     float longitude = location.coordinate.longitude;
     
-    [self removeCachedForecastForLatitude:latitude longitude:longitude time:time exclusions:exclusions];
+    [self removeCachedForecastForLatitude:latitude longitude:longitude time:time exclusions:exclusions extend:extendCommand];
+}
+
+- (void)removeCachedForecastForLocation:(CLLocation *)location
+                                   time:(NSNumber *)time
+                             exclusions:(NSArray *)exclusions
+{
+  [self removeCachedForecastForLocation:location time:time exclusions:exclusions extend:nil];
 }
 
 @end

--- a/Forecastr/Forecastr.h
+++ b/Forecastr/Forecastr.h
@@ -112,6 +112,7 @@ extern NSString *const kFCIconHurricane;
 
 + (id)sharedManager;
 
+
 /**
  * Requests the forecast for the given location and optional time and/or exclusions
  *
@@ -131,6 +132,30 @@ extern NSString *const kFCIconHurricane;
                      longitude:(double)lon
                           time:(NSNumber *)time
                     exclusions:(NSArray *)exclusions
+                       success:(void (^)(id JSON))success
+                       failure:(void (^)(NSError *error, id response))failure DEPRECATED_ATTRIBUTE;
+
+/**
+ * Requests the forecast for the given location and optional time and/or exclusions
+ *
+ * @return The JSON response
+ *
+ * @param lat The latitude of the location.
+ * @param long The longitude of the location.
+ * @param time (Optional) The desired time of the forecast in UNIX GMT format
+ * @param exclusions (Optional) An array which specifies which data blocks you would like left off the response
+ * @param extend (Optional) Extra commands that are sent to the server
+ * @param success A block object to be executed when the operation finishes successfully.
+ * @param failure A block object to be executed when the operation finishes unsuccessfully.
+ *
+ * @discussion For many locations, it can be 60 years in the past to 10 years in the future.
+ */
+
+- (void)getForecastForLatitude:(double)lat
+                     longitude:(double)lon
+                          time:(NSNumber *)time
+                    exclusions:(NSArray *)exclusions
+                        extend:(NSString*)extendCommand
                        success:(void (^)(id JSON))success
                        failure:(void (^)(NSError *error, id response))failure;
 
@@ -192,7 +217,26 @@ extern NSString *const kFCIconHurricane;
  * @param time (Optional) The desired time of the forecast in UNIX GMT format
  * @param exclusions (Optional) An array which specifies which data blocks you would like left off the response
  */
-- (void)removeCachedForecastForLatitude:(double)lat longitude:(double)lon time:(NSNumber *)time exclusions:(NSArray *)exclusions;
+- (void)removeCachedForecastForLatitude:(double)lat
+                              longitude:(double)lon
+                                   time:(NSNumber *)time
+                             exclusions:(NSArray *)exclusions DEPRECATED_ATTRIBUTE;
+
+/**
+ * Removes a cached forecast in case you want to refresh it prematurely
+ * Make sure you pass in the exact same params that you used in the original request
+ *
+ * @param lat The latitude of the location.
+ * @param long The longitude of the location.
+ * @param time (Optional) The desired time of the forecast in UNIX GMT format
+ * @param exclusions (Optional) An array which specifies which data blocks you would like left off the response
+ * @param extend (Optional) Extra commands that are sent to the server
+ */
+- (void)removeCachedForecastForLatitude:(double)lat
+                              longitude:(double)lon
+                                   time:(NSNumber *)time
+                             exclusions:(NSArray *)exclusions
+                                 extend:(NSString*)extendCommand;
 
 /**
  * Flushes all forecasts from the cache


### PR DESCRIPTION
Forecast.io added the `extend` option on 22 May 2013 (see the website for details). `extend` option is sent as a GET parameter. I've added the same parameter to this API. I also deprecated the old API without the `extend` option. Shouldn't affect existing applications.
