### PR TITLE
Added certificate file to podspec resources (as per @mmorey suggestion)

### DIFF
--- a/Forecastr.podspec
+++ b/Forecastr.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/iwasrobbed/Forecastr.git", :tag => "v0.1" }
   s.platform     = :ios, '7.0'
   s.source_files = 'Forecastr'
-  s.resources = "Forecastr/*.plist"
+  s.resources = "Forecastr/*.plist", "Forecastr/forecast.io.cer"
   s.framework  = 'CoreLocation'
   s.requires_arc = true
   s.dependency 'AFNetworking', '~> 2.0.1'


### PR DESCRIPTION
Corrects issue when Forecast.io calls fail in apps using Forecastr as a
pod due to the forecast.io.cer not being copied into the app bundle.

Problem manifests itself with the following error during Forecast.io
service calls: "Error Domain=NSURLErrorDomain Code=-999 "cancelled"

Fix provided by @mmorey.
