### PR TITLE
didUpdateToLocation was deprecated in iOS 6.0

### DIFF
--- a/Detailed Example App/Forecastr Detailed/FCLocationManager.m
+++ b/Detailed Example App/Forecastr Detailed/FCLocationManager.m
@@ -173,8 +173,10 @@ static NSString *kFCTimeoutError = @"There was a timeout while attempting to det
 # pragma mark - Location Services Delegate
 
 // Find and store a location measurement that meets the desired horizontal accuracy
-- (void)locationManager:(CLLocationManager *)manager didUpdateToLocation:(CLLocation *)newLocation fromLocation:(CLLocation *)oldLocation
+- (void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray *)locations
 {
+    CLLocation *newLocation = [locations lastObject];
+    
     // Test the age of the location measurement to determine if the measurement is cached (in which case, we don't want it)
     NSTimeInterval locationAge = -[newLocation.timestamp timeIntervalSinceNow];
     if (locationAge > 5.0) return;


### PR DESCRIPTION
locationManager:didUpdateToLocation:fromLocation: was deprecated in iOS 6.0. It is recommended that locationManager:didUpdateLocations: be used instead.

https://developer.apple.com/library/ios/documentation/CoreLocation/Reference/CLLocationManagerDelegate_Protocol/DeprecationAppendix/AppendixADeprecatedAPI.html#//apple_ref/occ/intfm/CLLocationManagerDelegate/locationManager:didUpdateToLocation:fromLocation:
