### PR TITLE
Update Forecastr.podspec to work with AFNetworking 2.4.1

### DIFF
--- a/Forecastr.podspec
+++ b/Forecastr.podspec
@@ -12,5 +12,5 @@ Pod::Spec.new do |s|
   s.resources = "Forecastr/*.plist"
   s.framework  = 'CoreLocation'
   s.requires_arc = true
-  s.dependency 'AFNetworking', '~> 2.0.1'
+  s.dependency 'AFNetworking', '~> 2.4.1'
 end


### PR DESCRIPTION
AFNetworking 2.0.X has issues with Xcode 6/iOS 8 so we need to update. Doesn't seem to break anything.
