### PR TITLE
Make sure the locationCode is passed along in helper functions

### DIFF
--- a/Forecastr/Forecastr+CLLocation.m
+++ b/Forecastr/Forecastr+CLLocation.m
@@ -38,8 +38,8 @@
 {
     float latitude = location.coordinate.latitude;
     float longitude = location.coordinate.longitude;
-    
-  [self getForecastForLatitude:latitude longitude:longitude time:time exclusions:exclusions extend:extendCommand success:^(id JSON) {
+
+    [self getForecastForLatitude:latitude longitude:longitude time:time exclusions:exclusions extend:extendCommand language:languageCode success:^(id JSON) {
         success(JSON);
     } failure:^(NSError *error, id response) {
         failure(error, response);
@@ -75,7 +75,7 @@
     float latitude = location.coordinate.latitude;
     float longitude = location.coordinate.longitude;
     
-    [self removeCachedForecastForLatitude:latitude longitude:longitude time:time exclusions:exclusions extend:extendCommand language:nil];
+    [self removeCachedForecastForLatitude:latitude longitude:longitude time:time exclusions:exclusions extend:extendCommand language:languageCode];
 }
 
 // Deprecated method


### PR DESCRIPTION
Made sure that the languageCode is passed along in the 'getForecastForLatitude' and 'removeCachedForecastForLatitude' methods in Forecastr+CLLocation.m.

This fixes iwasrobbed/Forecastr#18
