### PR TITLE
Changed the AFNetworking import type

### DIFF
--- a/Forecastr/ForecastrAPIClient.h
+++ b/Forecastr/ForecastrAPIClient.h
@@ -24,7 +24,7 @@
 // THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
-#import "AFNetworking.h"
+#import <AFNetworking/AFNetworking.h>
 
 @interface ForecastrAPIClient : AFHTTPSessionManager
 


### PR DESCRIPTION
This fixes compilation errors where the xcode reports the AFNetworking.h missing.
